### PR TITLE
Update instructions on adding verified owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,9 @@ For example, "my-service-account@test-project-42.google.com.iam.gserviceaccount.
 
 Then...
 
-1. Go to Google Search Console
+1. Go to [Google Webmaster Central](https://www.google.com/webmasters/verification/home)
 2. Click your verified property
-3. Select Verification details from the Settings gear next to your verified property.
-Under Verified owners, click Add an owner.
+3. Scroll down and click 'Add an owner'.
 4. Add your service account email address as an owner to the property.
 
 


### PR DESCRIPTION
The ability to add verified owners from the new Google Search Console seems to have been removed. The only way to add verified owners now is by using Webmaster Central. More info here: https://support.google.com/webmasters/thread/15210997?hl=en&msgid=15219693