### PR TITLE
added filter for "\n"EOF

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,8 @@ const jwtClient = new google.auth.JWT(
 const batch = fs
   .readFileSync('urls.txt')
   .toString()
-  .split('\n');
+  .split('\n')
+  .filter(Boolean); // filter out '\n"EOF
 
 jwtClient.authorize(function(err, tokens) {
   if (err) {


### PR DESCRIPTION
Dear swalker-888, I found an issue with urls.txt files ending with '\n'EOF. So I tried to filter out.